### PR TITLE
Take a stab at logging query to CloudWatch

### DIFF
--- a/src/main/java/edu/mit/kfg/priorart/parser/ParserHandler.java
+++ b/src/main/java/edu/mit/kfg/priorart/parser/ParserHandler.java
@@ -2,11 +2,13 @@ package edu.mit.kfg.priorart.parser;
 
 import com.uspto.query.parser.QueryParser;
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 
 public class ParserHandler implements RequestHandler<RequestClass, String> {
 	public String handleRequest(RequestClass request, Context context) {
 		QueryParser queryParser = new QueryParser();
+		System.out.println("request.query was: " + request.query);
 		return queryParser.pasrseToElastic(request.query, request.operator, request.filters);
 	}
 }


### PR DESCRIPTION
This is my attempt at logging the `request.query` to CloudWatch.

I’m not sure this is the correct way, but intended to just build and upyoload, but I can’t get Lambda to take my built JAR so I’m committing this possibly wrong code instead. Hopefully @joeltg will have a better time uploading this than me, or will figure out why it's wrong.

The end result, hopefully, is being able to see the `request.query` show up in [this list of log events at CloudWatch](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/aws/lambda/queryParser;streamFilter=typeLogStreamPrefix).

Affects #3